### PR TITLE
fix: napkin-context alreadyInjected check uses wrong entry type

### DIFF
--- a/extensions/napkin-context/index.ts
+++ b/extensions/napkin-context/index.ts
@@ -89,10 +89,8 @@ export default function (pi: ExtensionAPI) {
         .getEntries()
         .some(
           (e) =>
-            e.type === "message" &&
-            e.message.role === "custom" &&
-            (e.message as { customType?: string }).customType ===
-              "napkin-context",
+            e.type === "custom_message" &&
+            (e as { customType?: string }).customType === "napkin-context",
         );
 
       if (!alreadyInjected) {


### PR DESCRIPTION
The `alreadyInjected` guard checked for `e.type === 'message'` with `e.message.role === 'custom'`, but `appendCustomMessageEntry` stores entries as `type: 'custom_message'` with `customType` directly on the entry. The check never matched, so every resume/reload appended a duplicate napkin-context block at the end of the conversation instead of recognizing the existing one.