### PR TITLE
fix: kb_search/kb_read tool output respects Ctrl+O expand/collapse

### DIFF
--- a/extensions/napkin-context/index.ts
+++ b/extensions/napkin-context/index.ts
@@ -1,6 +1,12 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import {
+  type AgentToolResult,
+  type ExtensionAPI,
+  keyHint,
+  type Theme,
+  type ToolRenderResultOptions,
+} from "@mariozechner/pi-coding-agent";
 import { Markdown, Text } from "@mariozechner/pi-tui";
 import { Type } from "@sinclair/typebox";
 import { Napkin } from "napkin-ai";
@@ -15,6 +21,28 @@ function loadShowStatus(vaultPath: string): boolean {
   } catch {
     return true;
   }
+}
+
+function formatKbResult(
+  result: AgentToolResult<unknown>,
+  options: ToolRenderResultOptions,
+  theme: Theme,
+  maxCollapsedLines: number,
+): string {
+  const output = result.content
+    .flatMap((c) => (c.type === "text" ? [c.text] : []))
+    .join("\n")
+    .trimEnd();
+  if (!output) return "";
+  const lines = output.split(/\r?\n/);
+  const maxLines = options.expanded ? lines.length : maxCollapsedLines;
+  const displayLines = lines.slice(0, maxLines);
+  const remaining = lines.length - maxLines;
+  let text = `\n${displayLines.map((line) => theme.fg("toolOutput", line)).join("\n")}`;
+  if (remaining > 0) {
+    text += `${theme.fg("muted", `\n... (${remaining} more lines,`)} ${keyHint("app.tools.expand", "to expand")})`;
+  }
+  return text;
 }
 
 function getNapkin(cwd: string): Napkin {
@@ -164,6 +192,12 @@ export default function (pi: ExtensionAPI) {
         details: { results },
       };
     },
+    renderResult(result, options, theme, context) {
+      const t =
+        (context.lastComponent as Text | undefined) ?? new Text("", 0, 0);
+      t.setText(formatKbResult(result, options, theme, 15));
+      return t;
+    },
   });
 
   pi.registerTool({
@@ -182,6 +216,12 @@ export default function (pi: ExtensionAPI) {
         content: [{ type: "text", text: result.content }],
         details: { path: result.path },
       };
+    },
+    renderResult(result, options, theme, context) {
+      const t =
+        (context.lastComponent as Text | undefined) ?? new Text("", 0, 0);
+      t.setText(formatKbResult(result, options, theme, 10));
+      return t;
     },
   });
 }


### PR DESCRIPTION
## Problem

The `kb_search` and `kb_read` tools always rendered their output in full — Ctrl+O had no effect on them. This is because neither tool registered a `renderResult` callback, so pi's `ToolExecutionComponent.createResultFallback()` kicked in and dumped the entire text output unconditionally.

Built-in tools (`read`, `grep`, `ls`, `find`, `bash`, `write`) all register a `renderResult` that truncates to N lines when `!expanded` and appends a `... (N more lines, Ctrl+O to expand)` hint. The kb tools should behave the same way.

## Fix

Add a shared `formatKbResult` helper and wire it into both tools' `renderResult`, mirroring the built-in pattern.

Collapsed line caps:
- `kb_search`: 15 lines (matches built-in `grep`)
- `kb_read`:   10 lines (matches built-in `read`)

Defensive input normalization (matches `grep.js:127`):
- `.trimEnd()` to drop trailing vault-note newlines.
- `.split(/\r?\n/)` to handle CRLF files without rendering stray `\r`.

## Verification

Tested locally in a vault:

```
 kb_search
 **changelog/2026-04-14-prvtsidx-datapatch-oncall.md**
     - oncall
 ...
 ... (1257 more lines, ctrl+o to expand)
```

Ctrl+O expands to full output; Ctrl+O again collapses back to the truncated preview. Applies to both `kb_search` and `kb_read`.

## Notes

Merged in the `cad0p` fork as cad0p/pi-napkin#2. Single commit, clean cherry-pick onto upstream `main` (no conflicts).
