### PR TITLE
chore: fix biome formatter lint in distill status setter

### DIFF
--- a/extensions/distill/index.ts
+++ b/extensions/distill/index.ts
@@ -273,8 +273,7 @@ export default function (pi: ExtensionAPI) {
         if (showStatus) {
           ctx.ui.setStatus(
             "napkin-distill",
-            theme.fg("success", "✓") +
-              theme.fg("dim", ` distill ${elapsed}s`),
+            theme.fg("success", "✓") + theme.fg("dim", ` distill ${elapsed}s`),
           );
         }
         ctx.ui.notify(`Distillation complete (${elapsed}s)`, "success");


### PR DESCRIPTION
Pure formatter fix flagged by `npx @biomejs/biome check extensions/` — collapse two short theme calls onto one line. No behaviour change.

```
extensions/distill/index.ts:275
-            theme.fg("success", "✓") +
-              theme.fg("dim", ` distill ${elapsed}s`),
+            theme.fg("success", "✓") + theme.fg("dim", ` distill ${elapsed}s`),
```

Clears the last remaining Biome error so `biome check` passes clean across `extensions/`.

Merged in the `cad0p` fork as cad0p/pi-napkin#3.