### PR TITLE
chore: remove version pinning for napkin-ai

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@biomejs/biome": "^2.3.14"
   },
   "dependencies": {
-    "napkin-ai": "^0.8.1"
+    "napkin-ai": "*"
   },
   "peerDependencies": {
     "@mariozechner/pi-coding-agent": "*",


### PR DESCRIPTION
## Summary

Change napkin-ai dependency from `^0.8.1` to `*` (any version).

### Rationale

napkin-ai is a sibling package maintained in the same organization, not an external dependency. Version pinning adds unnecessary friction when napkin-ai ships new features that pi-napkin depends on — requiring a coordinated version bump in both packages.

With `*`, pi-napkin always uses the latest napkin-ai, which is the intended behavior for tightly coupled packages.

### Companion PRs

- [napkin#15](https://github.com/Michaelliv/napkin/pull/15) — adds global vault config fallback
- [napkin#16](https://github.com/Michaelliv/napkin/pull/16) — adds prepare script for git dependency builds
- [pi-napkin#8](https://github.com/Michaelliv/pi-napkin/pull/8) — uses napkin's native global config